### PR TITLE
Indy pkg remove ptr handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Navigate to [http://localhost:7001](), [http://localhost:7002]() and [http://loc
 ### Running the unit tests
 
 ```lang=bash
-docker-compose -f docker-compose.test.yaml run test-agent
+docker-compose -f docker-compose.test.yaml up --exit-code-from test-agent
 ```
 
 Note: You may need to cleanup previous docker network created using `docker network prune`

--- a/src/Streetcred.Sdk/Runtime/DefaultProofService.cs
+++ b/src/Streetcred.Sdk/Runtime/DefaultProofService.cs
@@ -300,16 +300,16 @@ namespace Streetcred.Sdk.Runtime
         public virtual Task<ProofRecord> GetAsync(Wallet wallet, string proofRecId) =>
             RecordService.GetAsync<ProofRecord>(wallet, proofRecId);
 
+        /// <inheritdoc />
         public virtual async Task<List<Credential>> ListCredentialsForProofRequestAsync(Wallet wallet,
             ProofRequest proofRequest, string attributeReferent)
         {
-            var search =
-                await AnonCreds.ProverSearchCredentialsForProofRequestAsync(wallet, proofRequest.ToJson());
-            var searchResult =
-                await AnonCreds.ProverFetchCredentialsForProofRequestAsync(search, attributeReferent, 100);
-
-            await AnonCreds.ProverCloseCredentialsSearchForProofRequestAsync(search);
-            return JsonConvert.DeserializeObject<List<Credential>>(searchResult);
+            using (var search =
+                await AnonCreds.ProverSearchCredentialsForProofRequestAsync(wallet, proofRequest.ToJson()))
+            {
+                var searchResult = await search.NextAsync(attributeReferent, 100);
+                return JsonConvert.DeserializeObject<List<Credential>>(searchResult);
+            }
         }
 
         #region Private Methods

--- a/src/Streetcred.Sdk/Streetcred.Sdk.csproj
+++ b/src/Streetcred.Sdk/Streetcred.Sdk.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Stateless" Version="4.2.1" />
-    <PackageReference Include="Hyperledger.Indy.Sdk" Version="1.6.7.1" />
+    <PackageReference Include="Hyperledger.Indy.Sdk" Version="1.6.7.2" />
     <PackageReference Include="Multiformats.Base" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Streetcred.Sdk/Streetcred.Sdk.csproj
+++ b/src/Streetcred.Sdk/Streetcred.Sdk.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Stateless" Version="4.2.1" />
-    <PackageReference Include="Hyperledger.Indy.Sdk" Version="1.6.7" />
+    <PackageReference Include="Hyperledger.Indy.Sdk" Version="1.6.7.1" />
     <PackageReference Include="Multiformats.Base" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Streetcred.Sdk.Tests/ProofTests.cs
+++ b/test/Streetcred.Sdk.Tests/ProofTests.cs
@@ -170,7 +170,7 @@ namespace Streetcred.Sdk.Tests
                 {
                     Name = "ProofReq",
                     Version = "1.0",
-                    Nonce = "123",
+                    Nonce = Guid.NewGuid().ToString(),
                     RequestedAttributes = new Dictionary<string, ProofAttributeInfo>
                     {
                         {"first-name-requirement", new ProofAttributeInfo {Name = "first_name"}}


### PR DESCRIPTION
This PR uses a version of the Indy.Sdk package that changes the handles used internally from `IntPtr` to `int`. This should potentially fix the internment exceptions thrown by the wrapper that wallet or item is invalid or closed.