### PR TITLE
Moving contract extensions back to SDK project

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Navigate to [http://localhost:7001](), [http://localhost:7002]() and [http://loc
 ### Running the unit tests
 
 ```lang=bash
-docker-compose -f docker-compose.test.yaml up --exit-code-from test-agent
+docker-compose -f docker-compose.test.yaml up --abort-on-container-exit --exit-code-from test-agent
 ```
 
 Note: You may need to cleanup previous docker network created using `docker network prune`

--- a/src/Streetcred.Sdk/Extensions/ConnectionServiceExtensions.cs
+++ b/src/Streetcred.Sdk/Extensions/ConnectionServiceExtensions.cs
@@ -5,8 +5,9 @@ using Streetcred.Sdk.Contracts;
 using Streetcred.Sdk.Models.Records;
 using Streetcred.Sdk.Models.Records.Search;
 using Streetcred.Sdk.Utils;
+// ReSharper disable CheckNamespace
 
-namespace Streetcred.Sdk.Extensions.Query
+namespace Streetcred.Sdk.Contracts
 {
     /// <summary>
     /// A collection of convenience methods for the <see cref="ICredentialService"/> class.

--- a/src/Streetcred.Sdk/Extensions/CredentialServiceExtensions.cs
+++ b/src/Streetcred.Sdk/Extensions/CredentialServiceExtensions.cs
@@ -1,12 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Hyperledger.Indy.WalletApi;
-using Streetcred.Sdk.Contracts;
 using Streetcred.Sdk.Models.Records;
 using Streetcred.Sdk.Models.Records.Search;
 using Streetcred.Sdk.Utils;
+// ReSharper disable CheckNamespace
 
-namespace Streetcred.Sdk.Extensions.Query
+namespace Streetcred.Sdk.Contracts
 {
     /// <summary>
     /// A collection of convenience methods for the <see cref="ICredentialService"/> class.

--- a/src/Streetcred.Sdk/Extensions/ProofServiceExtensions.cs
+++ b/src/Streetcred.Sdk/Extensions/ProofServiceExtensions.cs
@@ -1,12 +1,12 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Hyperledger.Indy.WalletApi;
-using Streetcred.Sdk.Contracts;
 using Streetcred.Sdk.Models.Records;
 using Streetcred.Sdk.Models.Records.Search;
 using Streetcred.Sdk.Utils;
+// ReSharper disable CheckNamespace
 
-namespace Streetcred.Sdk.Extensions.Query
+namespace Streetcred.Sdk.Contracts
 {
     /// <summary>
     /// A collection of convenience methods for the <see cref="IProofService"/> class.

--- a/src/Streetcred.Sdk/Models/AgentOwner.cs
+++ b/src/Streetcred.Sdk/Models/AgentOwner.cs
@@ -1,4 +1,4 @@
-﻿namespace Streetcred.Sdk.Models.Connections
+﻿namespace Streetcred.Sdk.Models
 {
     /// <summary>
     /// An object for containing agent ownership information.


### PR DESCRIPTION
#### Short description of what this resolves:
Ability to use extension methods in projects that don't include aspnet core stack

