### PR TITLE
Ledger service improvements

### DIFF
--- a/src/Streetcred.Sdk.Extensions/Runtime/MemoryCacheLedgerService.cs
+++ b/src/Streetcred.Sdk.Extensions/Runtime/MemoryCacheLedgerService.cs
@@ -66,5 +66,31 @@ namespace Streetcred.Sdk.Extensions.Runtime
 
             return result;
         }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// Looks up the transaction for the given <paramref name="sequenceId" /> and <paramref name="ledgerType" /> combination in the cache.
+        /// If found, returns the cached value, otherwise performs a ledger lookup and caches the result.
+        /// </summary>
+        /// <returns>The definition async.</returns>
+        /// <param name="pool">Pool.</param>
+        /// <param name="submitterDid">Submitter did.</param>
+        /// <param name="ledgerType">Ledger Type.</param>
+        /// <param name="sequenceId">Sequence identifier.</param>
+        public override async Task<string> LookupTransactionAsync(Pool pool, string submitterDid, string ledgerType, int sequenceId)
+        {
+            if (string.IsNullOrEmpty(ledgerType))
+                ledgerType = "DOMAIN";
+
+            if (!_memoryCache.TryGetValue<string>($"{ledgerType}-{sequenceId}", out var result))
+            {
+                result = await base.LookupTransactionAsync(pool, submitterDid, ledgerType, sequenceId);
+
+                // Save data in cache.
+                _memoryCache.Set($"{ledgerType}-{sequenceId}", result, _options);
+            }
+
+            return result;
+        }
     }
 }

--- a/src/Streetcred.Sdk.Extensions/Runtime/MemoryCacheLedgerService.cs
+++ b/src/Streetcred.Sdk.Extensions/Runtime/MemoryCacheLedgerService.cs
@@ -58,7 +58,7 @@ namespace Streetcred.Sdk.Extensions.Runtime
         {
             if (!_memoryCache.TryGetValue<ParseResponseResult>(definitionId, out var result))
             {
-                result = await base.LookupSchemaAsync(pool, submitterDid, definitionId);
+                result = await base.LookupDefinitionAsync(pool, submitterDid, definitionId);
                 
                 // Save data in cache.
                 _memoryCache.Set(definitionId, result, _options);

--- a/src/Streetcred.Sdk.Tests/SchemaServiceTests.cs
+++ b/src/Streetcred.Sdk.Tests/SchemaServiceTests.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Hyperledger.Indy.AnonCredsApi;
+using Hyperledger.Indy.DidApi;
+using Hyperledger.Indy.PoolApi;
+using Hyperledger.Indy.WalletApi;
+using Newtonsoft.Json.Linq;
+using Streetcred.Sdk.Contracts;
+using Streetcred.Sdk.Runtime;
+using Streetcred.Sdk.Utils;
+using Xunit;
+
+namespace Streetcred.Sdk.Tests
+{
+    public class SchemaServiceTests : IAsyncLifetime
+    {
+        private readonly IPoolService _poolService;
+        private readonly ISchemaService _schemaService;
+
+        private const string PoolName = "LedgerTestPool";
+        private const string IssuerConfig = "{\"id\":\"issuer_credential_test_wallet\"}";
+        private const string Credentials = "{\"key\":\"test_wallet_key\"}";
+
+        private Pool _pool;
+        private Wallet _issuerWallet;
+
+        public SchemaServiceTests()
+        {
+            var walletService = new DefaultWalletRecordService();
+            var ledgerService = new DefaultLedgerService();
+            var tailsService = new DefaultTailsService(ledgerService);
+
+            _poolService = new DefaultPoolService();
+            _schemaService = new DefaultSchemaService(walletService, ledgerService, tailsService);
+        }
+
+        [Fact]
+        public async Task CanCreateAndResolveSchema()
+        {
+            var issuer = await Did.CreateAndStoreMyDidAsync(_issuerWallet,
+                new { seed = "000000000000000000000000Steward1" }.ToJson());
+
+            var schemaName = $"Test-Schema-{Guid.NewGuid().ToString()}";
+            var schemaVersion = "1.0";
+            var schemaAttrNames = new[] {"test_attr_1", "test_attr_2"};
+
+            //Create a dummy schema
+            var schemaId = await _schemaService.CreateSchemaAsync(_pool, _issuerWallet, issuer.Did, schemaName, schemaVersion,
+                schemaAttrNames);
+
+            //Resolve it from the ledger with its identifier
+            var resultSchema = await _schemaService.LookupSchemaAsync(_pool, _issuerWallet, issuer.Did, schemaId);
+
+            var resultSchemaName = JObject.Parse(resultSchema)["name"].ToString();
+            var resultSchemaVersion = JObject.Parse(resultSchema)["version"].ToString();
+            var resultSchemaAttrNames = JObject.Parse(resultSchema)["attrNames"];
+            var sequenceId = Convert.ToInt32(JObject.Parse(resultSchema)["seqNo"].ToString());
+
+            Assert.Equal(schemaName, resultSchemaName);
+            Assert.Equal(schemaVersion, resultSchemaVersion);
+            //Assert.Equal(schemaAttrNames, resultSchemaAttrNames);
+
+            //Resolve it from the ledger with its sequence Id
+            var secondResultSchema = await _schemaService.LookupSchemaAsync(_pool, _issuerWallet, issuer.Did, sequenceId);
+
+            Assert.Equal(resultSchema,secondResultSchema);
+        }
+
+        public async Task InitializeAsync()
+        {
+            await Wallet.DeleteWalletAsync(IssuerConfig, Credentials);
+            try
+            {
+                await Wallet.CreateWalletAsync(IssuerConfig, Credentials);
+            }
+            catch (WalletExistsException)
+            {
+                // OK
+            }
+
+            _issuerWallet = await Wallet.OpenWalletAsync(IssuerConfig, Credentials);
+
+            try
+            {
+                await _poolService.CreatePoolAsync(PoolName, Path.GetFullPath("pool_genesis.txn"), 2);
+            }
+            catch (PoolLedgerConfigExistsException)
+            {
+                // OK
+            }
+            _pool = await _poolService.GetPoolAsync(PoolName, 2);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_issuerWallet != null) await _issuerWallet.CloseAsync();
+            if (_pool != null) await _pool.CloseAsync();
+
+            await Wallet.DeleteWalletAsync(IssuerConfig, Credentials);
+            await Pool.DeletePoolLedgerConfigAsync(PoolName);
+        }
+    }
+}

--- a/src/Streetcred.Sdk/Contracts/ILedgerService.cs
+++ b/src/Streetcred.Sdk/Contracts/ILedgerService.cs
@@ -48,11 +48,12 @@ namespace Streetcred.Sdk.Contracts
         /// </summary>
         /// <param name="pool">The pool.</param>
         /// <param name="submitterDid">The submitter did.</param>
+        /// <param name="ledgerType">The ledger type.</param>
         /// <param name="sequenceId">The sequence identifier.</param>
         /// <returns>
         /// The transaction async.
         /// </returns>
-        Task<string> LookupTransactionAsync(Pool pool, string submitterDid, int sequenceId);
+        Task<string> LookupTransactionAsync(Pool pool, string submitterDid, string ledgerType, int sequenceId);
 
         /// <summary>
         /// Lookups the definition async.

--- a/src/Streetcred.Sdk/Contracts/ILedgerService.cs
+++ b/src/Streetcred.Sdk/Contracts/ILedgerService.cs
@@ -33,7 +33,7 @@ namespace Streetcred.Sdk.Contracts
             string attributeName, object value);
 
         /// <summary>
-        /// Lookups the schema async.
+        /// Lookup the schema async.
         /// </summary>
         /// <param name="pool">The pool.</param>
         /// <param name="submitterDid">The submitter did.</param>
@@ -42,6 +42,17 @@ namespace Streetcred.Sdk.Contracts
         /// The schema async.
         /// </returns>
         Task<ParseResponseResult> LookupSchemaAsync(Pool pool, string submitterDid, string schemaId);
+
+        /// <summary>
+        /// Lookup the ledger transaction async.
+        /// </summary>
+        /// <param name="pool">The pool.</param>
+        /// <param name="submitterDid">The submitter did.</param>
+        /// <param name="sequenceId">The sequence identifier.</param>
+        /// <returns>
+        /// The transaction async.
+        /// </returns>
+        Task<string> LookupTransactionAsync(Pool pool, string submitterDid, int sequenceId);
 
         /// <summary>
         /// Lookups the definition async.
@@ -85,18 +96,19 @@ namespace Streetcred.Sdk.Contracts
         Task<ParseRegistryResponseResult> LookupRevocationRegistryAsync(Pool pool, string revocationRegistryId, long timestamp);
 
         /// <summary>
-        /// Registers the trust anchor async.
+        /// Registers the nym async.
         /// </summary>
         /// <param name="wallet">The wallet.</param>
         /// <param name="pool">The pool.</param>
         /// <param name="submitterDid">The submitter did.</param>
         /// <param name="theirDid">Their did.</param>
         /// <param name="theirVerkey">Their verkey.</param>
+        /// <param name="role">Role the new nym will assume.</param>
         /// <returns>
-        /// The trust anchor async.
+        /// Registration async.
         /// </returns>
-        Task RegisterTrustAnchorAsync(Wallet wallet, Pool pool, string submitterDid, string theirDid,
-            string theirVerkey);
+        Task RegisterNymAsync(Wallet wallet, Pool pool, string submitterDid, string theirDid,
+            string theirVerkey, string role);
 
         /// <summary>
         /// Registers the credential definition async.

--- a/src/Streetcred.Sdk/Contracts/ISchemaService.cs
+++ b/src/Streetcred.Sdk/Contracts/ISchemaService.cs
@@ -65,17 +65,7 @@ namespace Streetcred.Sdk.Contracts
         /// <param name="credentialDefinitionId">The credential definition identifier.</param>
         /// <returns>The credential definition record.</returns>
         Task<DefinitionRecord> GetCredentialDefinitionAsync(Wallet wallet, string credentialDefinitionId);
-
-        /// <summary>
-        /// Looks up the credential definition on the ledger.
-        /// </summary>
-        /// <param name="pool">The pool.</param>
-        /// <param name="wallet">The wallet.</param>
-        /// <param name="submitterDid">The submitter did.</param>
-        /// <param name="sequenceId">The sequence identifier of the definition to resolve.</param>
-        /// <returns>A json string of the credential definition</returns>
-        Task<string> LookupCredentialDefinitionAsync(Pool pool, Wallet wallet, string submitterDid, int sequenceId);
-
+        
         /// <summary>
         /// Looks up the credential definition on the ledger.
         /// </summary>

--- a/src/Streetcred.Sdk/Contracts/ISchemaService.cs
+++ b/src/Streetcred.Sdk/Contracts/ISchemaService.cs
@@ -21,7 +21,7 @@ namespace Streetcred.Sdk.Contracts
         /// <param name="name">The name.</param>
         /// <param name="version">The version.</param>
         /// <param name="attributeNames">The attribute names.</param>
-        /// <returns>The shema identifier of the stored schema object.
+        /// <returns>The schema identifier of the stored schema object.
         /// This identifier can be used for ledger schema lookup.</returns>
         Task<string> CreateSchemaAsync(Pool pool, Wallet wallet, string issuerDid, string name, string version,
             string[] attributeNames);
@@ -73,8 +73,8 @@ namespace Streetcred.Sdk.Contracts
         /// <param name="wallet">The wallet.</param>
         /// <param name="submitterDid">The submitter did.</param>
         /// <param name="sequenceId">The sequence identifier of the definition to resolve.</param>
-        /// <returns></returns>
-        Task<string> LookupDefinitionAsync(Pool pool, Wallet wallet, string submitterDid, int sequenceId);
+        /// <returns>A json string of the credential definition</returns>
+        Task<string> LookupCredentialDefinitionAsync(Pool pool, Wallet wallet, string submitterDid, int sequenceId);
 
         /// <summary>
         /// Looks up the credential definition on the ledger.
@@ -83,8 +83,18 @@ namespace Streetcred.Sdk.Contracts
         /// <param name="wallet">The wallet.</param>
         /// <param name="submitterDid">The submitter did.</param>
         /// <param name="definitionId">The identifier of the definition to resolve.</param>
-        /// <returns></returns>
-        Task<string> LookupDefinitionAsync(Pool pool, Wallet wallet, string submitterDid, string definitionId);
+        /// <returns>A json string of the credential definition</returns>
+        Task<string> LookupCredentialDefinitionAsync(Pool pool, Wallet wallet, string submitterDid, string definitionId);
+
+        /// <summary>
+        /// Looks up the schema definition on the ledger given a credential definition identifier.
+        /// </summary>
+        /// <param name="pool">The pool.</param>
+        /// <param name="wallet">The wallet.</param>
+        /// <param name="submitterDid">The submitter did.</param>
+        /// <param name="credentialDefinitionId">The credential definition id.</param>
+        /// <returns>A json string of the schema</returns>
+        Task<string> LookupSchemaFromCredentialDefinitionAsync(Pool pool, Wallet wallet, string submitterDid, string credentialDefinitionId);
 
         /// <summary>
         /// Looks up the schema definition on the ledger.
@@ -93,7 +103,7 @@ namespace Streetcred.Sdk.Contracts
         /// <param name="wallet">The wallet.</param>
         /// <param name="submitterDid">The submitter did.</param>
         /// <param name="sequenceId">The sequence identifier of the schema to resolve.</param>
-        /// <returns></returns>
+        /// <returns>A json string of the schema</returns>
         Task<string> LookupSchemaAsync(Pool pool, Wallet wallet, string submitterDid, int sequenceId);
 
         /// <summary>
@@ -103,7 +113,7 @@ namespace Streetcred.Sdk.Contracts
         /// <param name="wallet">The wallet.</param>
         /// <param name="submitterDid">The submitter did.</param>
         /// <param name="schemaId">The identifier of the schema definition to resolve.</param>
-        /// <returns></returns>
+        /// <returns>A json string of the schema</returns>
         Task<string> LookupSchemaAsync(Pool pool, Wallet wallet, string submitterDid, string schemaId);
     }
 }

--- a/src/Streetcred.Sdk/Contracts/ISchemaService.cs
+++ b/src/Streetcred.Sdk/Contracts/ISchemaService.cs
@@ -65,5 +65,45 @@ namespace Streetcred.Sdk.Contracts
         /// <param name="credentialDefinitionId">The credential definition identifier.</param>
         /// <returns>The credential definition record.</returns>
         Task<DefinitionRecord> GetCredentialDefinitionAsync(Wallet wallet, string credentialDefinitionId);
+
+        /// <summary>
+        /// Looks up the credential definition on the ledger.
+        /// </summary>
+        /// <param name="pool">The pool.</param>
+        /// <param name="wallet">The wallet.</param>
+        /// <param name="submitterDid">The submitter did.</param>
+        /// <param name="sequenceId">The sequence identifier of the definition to resolve.</param>
+        /// <returns></returns>
+        Task<string> LookupDefinitionAsync(Pool pool, Wallet wallet, string submitterDid, int sequenceId);
+
+        /// <summary>
+        /// Looks up the credential definition on the ledger.
+        /// </summary>
+        /// <param name="pool">The pool.</param>
+        /// <param name="wallet">The wallet.</param>
+        /// <param name="submitterDid">The submitter did.</param>
+        /// <param name="definitionId">The identifier of the definition to resolve.</param>
+        /// <returns></returns>
+        Task<string> LookupDefinitionAsync(Pool pool, Wallet wallet, string submitterDid, string definitionId);
+
+        /// <summary>
+        /// Looks up the schema definition on the ledger.
+        /// </summary>
+        /// <param name="pool">The pool.</param>
+        /// <param name="wallet">The wallet.</param>
+        /// <param name="submitterDid">The submitter did.</param>
+        /// <param name="sequenceId">The sequence identifier of the schema to resolve.</param>
+        /// <returns></returns>
+        Task<string> LookupSchemaAsync(Pool pool, Wallet wallet, string submitterDid, int sequenceId);
+
+        /// <summary>
+        /// Looks up the schema definition on the ledger.
+        /// </summary>
+        /// <param name="pool">The pool.</param>
+        /// <param name="wallet">The wallet.</param>
+        /// <param name="submitterDid">The submitter did.</param>
+        /// <param name="schemaId">The identifier of the schema definition to resolve.</param>
+        /// <returns></returns>
+        Task<string> LookupSchemaAsync(Pool pool, Wallet wallet, string submitterDid, string schemaId);
     }
 }

--- a/src/Streetcred.Sdk/Runtime/DefaultLedgerService.cs
+++ b/src/Streetcred.Sdk/Runtime/DefaultLedgerService.cs
@@ -107,13 +107,13 @@ namespace Streetcred.Sdk.Runtime
         }
 
         /// <inheritdoc />
-        public virtual async Task RegisterTrustAnchorAsync(Wallet wallet, Pool pool, string submitterDid, string theirDid,
-            string theirVerkey)
+        public virtual async Task RegisterNymAsync(Wallet wallet, Pool pool, string submitterDid, string theirDid,
+            string theirVerkey, string role)
         {
             if (DidUtils.IsFullVerkey(theirVerkey))
                 theirVerkey = await Did.AbbreviateVerkeyAsync(theirDid, theirVerkey);
 
-            var req = await Ledger.BuildNymRequestAsync(submitterDid, theirDid, theirVerkey, null, "TRUST_ANCHOR");
+            var req = await Ledger.BuildNymRequestAsync(submitterDid, theirDid, theirVerkey, null, role);
             var res = await Ledger.SignAndSubmitRequestAsync(pool, wallet, submitterDid, req);
 
             EnsureSuccessResponse(res);
@@ -124,8 +124,17 @@ namespace Streetcred.Sdk.Runtime
         {
             var req = await Ledger.BuildGetAttribRequestAsync(null, targetDid, attributeName, null, null);
             var res = await Ledger.SubmitRequestAsync(pool, req);
-
+            
             return null;
+        }
+
+        /// <inheritdoc />
+        public virtual async Task<string> LookupTransactionAsync(Pool pool, string submitterDid, int sequenceId)
+        {
+            var req = await Ledger.BuildGetTxnRequestAsync(submitterDid, sequenceId);
+            var res = await Ledger.SubmitRequestAsync(pool, req);
+
+            return res;
         }
 
         /// <inheritdoc />

--- a/src/Streetcred.Sdk/Runtime/DefaultLedgerService.cs
+++ b/src/Streetcred.Sdk/Runtime/DefaultLedgerService.cs
@@ -129,9 +129,9 @@ namespace Streetcred.Sdk.Runtime
         }
 
         /// <inheritdoc />
-        public virtual async Task<string> LookupTransactionAsync(Pool pool, string submitterDid, int sequenceId)
+        public virtual async Task<string> LookupTransactionAsync(Pool pool, string submitterDid, string ledgerType, int sequenceId)
         {
-            var req = await Ledger.BuildGetTxnRequestAsync(submitterDid, sequenceId);
+            var req = await Ledger.BuildGetTxnRequestAsync(submitterDid, ledgerType, sequenceId);
             var res = await Ledger.SubmitRequestAsync(pool, req);
 
             return res;

--- a/src/Streetcred.Sdk/Runtime/DefaultSchemaService.cs
+++ b/src/Streetcred.Sdk/Runtime/DefaultSchemaService.cs
@@ -154,15 +154,7 @@ namespace Streetcred.Sdk.Runtime
 
             return credentialDefinition.CredDefId;
         }
-
-        /// TODO this should return a definition object
-        /// <inheritdoc />
-        public virtual async Task<string> LookupCredentialDefinitionAsync(Pool pool, Wallet wallet, string submitterDid, int sequenceId)
-        {
-            var result = await LedgerService.LookupTransactionAsync(pool, submitterDid, null, sequenceId);
-            return result;
-        }
-
+        
         /// TODO this should return a definition object
         /// <inheritdoc />
         public virtual async Task<string> LookupCredentialDefinitionAsync(Pool pool, Wallet wallet, string submitterDid, string definitionId)

--- a/src/Streetcred.Sdk/Runtime/DefaultSchemaService.cs
+++ b/src/Streetcred.Sdk/Runtime/DefaultSchemaService.cs
@@ -43,6 +43,38 @@ namespace Streetcred.Sdk.Runtime
             return schemaRecord.SchemaId;
         }
 
+        /// TODO this should return a definition object
+        /// <inheritdoc />
+        public virtual async Task<string> LookupDefinitionAsync(Pool pool, Wallet wallet, string submitterDid, int sequenceId)
+        {
+            var result = await LedgerService.LookupTransactionAsync(pool, submitterDid, sequenceId);
+            return result;
+        }
+
+        /// TODO this should return a definition object
+        /// <inheritdoc />
+        public virtual async Task<string> LookupDefinitionAsync(Pool pool, Wallet wallet, string submitterDid, string definitionId)
+        {
+            var result = await LedgerService.LookupDefinitionAsync(pool, submitterDid, definitionId);
+            return result?.ObjectJson;
+        }
+
+        /// TODO this should return a schema object
+        /// <inheritdoc />
+        public virtual async Task<string> LookupSchemaAsync(Pool pool, Wallet wallet, string submitterDid, int sequenceId)
+        {
+            var result = await LedgerService.LookupTransactionAsync(pool, submitterDid, sequenceId);
+            return result;
+        }
+
+        /// TODO this should return a schema object
+        /// <inheritdoc />
+        public virtual async Task<string> LookupSchemaAsync(Pool pool, Wallet wallet, string submitterDid, string schemaId)
+        {
+            var result = await LedgerService.LookupSchemaAsync(pool, submitterDid, schemaId);
+            return result?.ObjectJson;
+        }
+
         /// <inheritdoc />
         public virtual async Task<string> CreateCredentialDefinitionAsync(Pool pool, Wallet wallet, string schemaId,
             string issuerDid, bool supportsRevocation, int maxCredentialCount, Uri tailsBaseUri)

--- a/test/Streetcred.Sdk.Tests/ProofTests.cs
+++ b/test/Streetcred.Sdk.Tests/ProofTests.cs
@@ -149,7 +149,7 @@ namespace Streetcred.Sdk.Tests
 
         [Fact]
         public async Task CredentialProofDemo()
-        {
+        { 
             //Setup a connection and issue the credentials to the holder
             var (issuerConnection, _) = await Scenarios.EstablishConnectionAsync(
                 _connectionService, _messages, _issuerWallet, _holderWallet);


### PR DESCRIPTION
#### Short description of what this resolves:

Makes the RegisterTrustAnchor method generic.

Adds the ability to resolve transactions from the ledger via their sequence id which allows schema resolution given a credential definition.

#### Changes proposed in this pull request:

- Replace the RegisterTrustAnchor method with RegisterNym and allow the ability to specify the nym role.
- Adds the ability to resolve a transaction from the ledger via its sequence id.
- Adds the ability to resolve a schema from the ledger via its sequence id.
- Adds a convenience method to the schema service which allow resolving a schema from a credential definition id.
- Extended the caching enabled version of the ledger service to cache resolved ledger transactions.