### PR TITLE
Add DefinitionRecord.SchemaId

### DIFF
--- a/src/Streetcred.Sdk/Models/Records/DefinitionRecord.cs
+++ b/src/Streetcred.Sdk/Models/Records/DefinitionRecord.cs
@@ -18,6 +18,12 @@
         public string DefinitionId { get; set; }
 
         /// <summary>
+        /// Gets or sets the identifier of the schema the definition is derived from.
+        /// </summary>
+        /// <value>The schema identifier.</value>
+        public string SchemaId { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this definition supports credential revocation.
         /// </summary>
         /// <value>

--- a/src/Streetcred.Sdk/Runtime/DefaultSchemaService.cs
+++ b/src/Streetcred.Sdk/Runtime/DefaultSchemaService.cs
@@ -118,6 +118,7 @@ namespace Streetcred.Sdk.Runtime
 
             definitionRecord.SupportsRevocation = supportsRevocation;
             definitionRecord.DefinitionId = credentialDefinition.CredDefId;
+            definitionRecord.SchemaId = schemaId;
 
             definitionRecord.Tags.Add(TagConstants.SchemaId, schemaId);
 

--- a/test/Streetcred.Sdk.Tests/SchemaServiceTests.cs
+++ b/test/Streetcred.Sdk.Tests/SchemaServiceTests.cs
@@ -99,6 +99,10 @@ namespace Streetcred.Sdk.Tests
 
             Assert.Equal(schemaName, resultSchemaName);
             Assert.Equal(schemaVersion, resultSchemaVersion);
+
+            var recordResult = await _schemaService.GetCredentialDefinitionAsync(_issuerWallet, credId);
+
+            Assert.Equal(schemaId, recordResult.SchemaId);
         }
 
         public async Task InitializeAsync()


### PR DESCRIPTION
As well as tagging the `DefinitionRecord` with the schema id, it's
useful to also have it in the record itself to make subsequent fetches
easier.

- Add `DefinitionRecord.SchemaId` attribute.
- Ensure `CreateCredentialDefinitionAsync()` populates the field.
- Update test: `CanCreateAndResolveCredentialDefinitionAndSchema`
